### PR TITLE
Improve DX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 dist
+node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -16,12 +16,11 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "devDependencies": {
-    "ava": "^0.15.2",
-    "babel-cli": "^6.11.4",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.11.5",
-    "standard": "^7.1.2"
+    "ava": "^0.16.0",
+    "babel-cli": "^6.18.0",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "babel-register": "^6.18.0"
   },
   "dependencies": {
     "deepmerge": "^1.3.1",


### PR DESCRIPTION
I've ignored `node_modules` and `npm-debug.log` because they are project generated _assets_. In my opinion it is easier to exclude them using `gitignore` than requiring every contributor to add those entries to their global git config.

I've also removed `standard` because it does not seem to be used anymore (considering the number of errors).